### PR TITLE
change suppliers to retrieve a value once and cache the result

### DIFF
--- a/src/main/kotlin/org/jitsi/metaconfig/supplier/ConfigValueSupplier.kt
+++ b/src/main/kotlin/org/jitsi/metaconfig/supplier/ConfigValueSupplier.kt
@@ -12,8 +12,9 @@ abstract class ConfigValueSupplier<ValueType : Any>(
     private val deprecation: Deprecation
 ) {
     private var deprecationWarningLogged = false
-    fun get(): ValueType {
-        return doGet().also {
+
+    private val value: ValueType by lazy {
+        doGet().also {
             if (deprecation is Deprecation.Deprecated.Soft && !deprecationWarningLogged) {
                 MetaconfigSettings.logger.warn {
                     "A value was retrieved via $this which is deprecated: ${deprecation.msg}"
@@ -26,6 +27,9 @@ abstract class ConfigValueSupplier<ValueType : Any>(
             }
         }
     }
+
+    fun get(): ValueType = value
+
     /**
      * Get the value from this supplier.  Throws [ConfigException.UnableToRetrieve]
      * if the property wasn't found.

--- a/src/test/kotlin/org/jitsi/metaconfig/supplier/ConfigSourceSupplierTest.kt
+++ b/src/test/kotlin/org/jitsi/metaconfig/supplier/ConfigSourceSupplierTest.kt
@@ -23,13 +23,6 @@ class ConfigSourceSupplierTest : ShouldSpec({
             typeOf<Int>(),
             noDeprecation()
         )
-        should("query the source every time when accessed") {
-            every { configSource.getterFor(typeOf<Int>()) } returns { 42 }
-
-            css.get() shouldBe 42
-            css.get() shouldBe 42
-            verify(exactly = 2) { configSource.getterFor(typeOf<Int>()) }
-        }
         context("when the property isn't present") {
             every { configSource.getterFor(typeOf<Int>()) } throws ConfigException.UnableToRetrieve.NotFound("not found")
             shouldThrow<ConfigException.UnableToRetrieve.NotFound> {

--- a/src/test/kotlin/org/jitsi/metaconfig/supplier/ConfigValueSupplierTest.kt
+++ b/src/test/kotlin/org/jitsi/metaconfig/supplier/ConfigValueSupplierTest.kt
@@ -21,6 +21,30 @@ class ConfigValueSupplierTest : ShouldSpec({
     }
 
     context("A ConfigValueSupplier") {
+        should("cache the retrieved value") {
+            var supplierCallCount = 0
+            val s = LambdaSupplier("foo") {
+                supplierCallCount++
+                42
+            }
+            s.get() shouldBe 42
+            supplierCallCount shouldBe 1
+            s.get() shouldBe 42
+            supplierCallCount shouldBe 1
+        }
+        should("throw the exception every time if it isn't found") {
+            var supplierCallCount = 0
+            val s = LambdaSupplier<Int>("foo") {
+                supplierCallCount++
+                throw ConfigException.UnableToRetrieve.NotFound("not found")
+            }
+            shouldThrow<ConfigException.UnableToRetrieve.NotFound> {
+                s.get()
+            }
+            shouldThrow<ConfigException.UnableToRetrieve.NotFound> {
+                s.get()
+            }
+        }
         context("marked as soft deprecated") {
             context("that finds a value") {
                 val s = LambdaSupplier(softDeprecation("deprecated")) { 42 }


### PR DESCRIPTION
Previously every time a value was accessed we would go back through the suppliers to retrieve it.  This may be a handy feature to enable in the future (to support props which we want to be able to change at runtime) but for now our main use case is read-once and it's more important to avoid the extra work on every access.

Down the line, we can pass a param to `ConfigValueSupplier` (like the `Deprecation` param) which determines whether or not the value is cached.