### PR TITLE
Add support for 'conditional' properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ class Foo {
         retrieve("old.path.app.enabled".from(legacyConfigSource).softDeprecated("use 'new.path.app.enabled' in new config source")
         retrieve("new.path.app.enabled".from(newConfigSource))
     }
+
+    // Only allow access to port if 'enabled' is true (throws an exception otherwise)
+    val port: Int by conditionalconfig(::enabled) {
+        retrieve("path.to.port".from(newConfigSource))
+    }
 }
 ```
 

--- a/docs/DelegateHelpers.md
+++ b/docs/DelegateHelpers.md
@@ -76,6 +76,21 @@ val port: Int by config {
     retrieve("default") { 8080 }
 }
 ```
+---
+### Conditionally enabling a property
+It's possible to guard access to a property if it should only be used based on the value of another property (e.g. a feature being enabled).
+
+The following example will only allow accessing `port` if `serverEnabled` evaluates to true.  If it doesn't, then `ConfigException.UnableToRetrieve.ConditionNotMet` will be thrown.
+
+```kotlin
+val serverEnabled: Boolean by config("app.server.enabled".from(config))
+
+val port: Int by conditionalconfig(::serverEnabled) {
+    retrieve("path.to.port".from(myConfig))
+    // Since the lambda is opaque, the description gives some context
+    retrieve("default") { 8080 }
+}
+```
 
 ---
 ### Optional properties

--- a/docs/SupplierTypes.md
+++ b/docs/SupplierTypes.md
@@ -74,3 +74,16 @@ val port: ConfigValueSupplier<Int> = FallbackSupplier(
 )
 ```
 
+## ConditionalSupplier
+A `ConditionalSupplier` is a effectively a wrapper around a `FallbackSupplier` with a predicate guard.  Only if the predicate passes will it try to retrieve from the inner supplier.
+
+This can be useful if a property should only be accessed based on some condition (like a feature being enabled).  The following example will throw [ConfigException.UnableToRetrieve.ConditionNotMet]
+when calling `port.get()` if `serverEnabled` is not true:
+```kotlin
+val port: ConfigValueSupplier<Int> = ConditionalSupplier(
+    { serverEnabled },
+    listOf(
+        ConfigSourceSupplier("legacy.path.port", legacyConfigSource, typeOf<Int>()),
+        LambdaSupplier { someLegacyConfigObject.port }
+    )
+)

--- a/src/main/kotlin/org/jitsi/metaconfig/ConfigException.kt
+++ b/src/main/kotlin/org/jitsi/metaconfig/ConfigException.kt
@@ -17,6 +17,8 @@ sealed class ConfigException(msg: String) : Exception(msg) {
         class WrongType(msg: String) : UnableToRetrieve(msg)
 
         class Deprecated(msg: String) : UnableToRetrieve(msg)
+
+        class ConditionNotMet(msg: String) : UnableToRetrieve(msg)
     }
 
     /**

--- a/src/main/kotlin/org/jitsi/metaconfig/Delegates.kt
+++ b/src/main/kotlin/org/jitsi/metaconfig/Delegates.kt
@@ -1,5 +1,6 @@
 package org.jitsi.metaconfig
 
+import org.jitsi.metaconfig.supplier.ConditionalSupplier
 import org.jitsi.metaconfig.supplier.ConfigValueSupplier
 import org.jitsi.metaconfig.supplier.FallbackSupplier
 import kotlin.reflect.KProperty
@@ -81,4 +82,9 @@ inline fun <reified T : Any> optionalconfig(configPropertyState: ConfigPropertyS
 inline fun <reified T : Any> optionalconfig(block: SupplierBuilder<T>.() -> Unit): OptionalConfigDelegate<T> {
     val builder = SupplierBuilder<T>(typeOf<T>()).apply(block)
     return OptionalConfigDelegate(FallbackSupplier(builder.suppliers))
+}
+
+inline fun <reified T : Any> conditionalconfig(noinline predicate: () -> Boolean, block: SupplierBuilder<T>.() -> Unit): ConfigDelegate<T> {
+    val supplier = SupplierBuilder<T>(typeOf<T>()).apply(block)
+    return ConfigDelegate(ConditionalSupplier(predicate, supplier.suppliers))
 }

--- a/src/main/kotlin/org/jitsi/metaconfig/supplier/ConditionalSupplier.kt
+++ b/src/main/kotlin/org/jitsi/metaconfig/supplier/ConditionalSupplier.kt
@@ -1,0 +1,27 @@
+package org.jitsi.metaconfig.supplier
+
+import org.jitsi.metaconfig.ConfigException
+import org.jitsi.metaconfig.noDeprecation
+
+/**
+ * A [ConfigValueSupplier] which searches through multiple inner [ConfigValueSupplier]s, in order,
+ * *if* the passed [predicate] returns true.  If the predicate returns false, then
+ * [ConfigException.UnableToRetrieve.ConditionNotMet] is thrown.
+ */
+class ConditionalSupplier<ValueType : Any>(
+    private val predicate: () -> Boolean,
+    innerSuppliers: List<ConfigValueSupplier<ValueType>>
+) : ConfigValueSupplier<ValueType>(noDeprecation()) {
+    private val innerSupplier = FallbackSupplier(innerSuppliers)
+
+    override fun doGet(): ValueType {
+        if (predicate()) {
+            return innerSupplier.get()
+        }
+        else {
+            throw ConfigException.UnableToRetrieve.ConditionNotMet("Predicate not met on conditional property")
+        }
+    }
+
+    override fun toString(): String = "${this::class.simpleName}: predicate wrapper around: $innerSupplier"
+}

--- a/src/test/kotlin/org/jitsi/metaconfig/ConfigPropertyStateTest.kt
+++ b/src/test/kotlin/org/jitsi/metaconfig/ConfigPropertyStateTest.kt
@@ -60,5 +60,19 @@ class ConfigPropertyStateTest : ShouldSpec({
             }
             obj.num shouldBe 43
         }
+        should("allow conditionally enabling a property") {
+            val obj = object {
+                val enabledNum: Int by conditionalconfig({true}) {
+                    retrieve("new.num".from(newConfig))
+                }
+                val disabledNum: Int by conditionalconfig({false}) {
+                    retrieve("new.num".from(newConfig))
+                }
+            }
+            obj.enabledNum shouldBe 43
+            shouldThrow<ConfigException.UnableToRetrieve.ConditionNotMet> {
+                obj.disabledNum
+            }
+        }
     }
 })

--- a/src/test/kotlin/org/jitsi/metaconfig/supplier/ConditionalSupplierTest.kt
+++ b/src/test/kotlin/org/jitsi/metaconfig/supplier/ConditionalSupplierTest.kt
@@ -1,0 +1,35 @@
+package org.jitsi.metaconfig.supplier
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import org.jitsi.metaconfig.ConfigException
+
+class ConditionalSupplierTest : ShouldSpec({
+    context("a conditional supplier") {
+        context("when the condition is met") {
+            val cs = ConditionalSupplier<Int>(
+                { true },
+                listOf(
+                    LambdaSupplier { 42 }
+                )
+            )
+            should("return the value") {
+                cs.get() shouldBe 42
+            }
+        }
+        context("when the condition is not met") {
+            val cs = ConditionalSupplier<Int>(
+                { false },
+                listOf(
+                    LambdaSupplier { 42 }
+                )
+            )
+            should("throw an exception") {
+                shouldThrow<ConfigException.UnableToRetrieve.ConditionNotMet> {
+                    cs.get()
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/org/jitsi/metaconfig/supplier/ConfigSourceSupplierTest.kt
+++ b/src/test/kotlin/org/jitsi/metaconfig/supplier/ConfigSourceSupplierTest.kt
@@ -2,10 +2,8 @@ package org.jitsi.metaconfig.supplier
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.ShouldSpec
-import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
 import org.jitsi.metaconfig.ConfigException
 import org.jitsi.metaconfig.ConfigSource
 import org.jitsi.metaconfig.noDeprecation


### PR DESCRIPTION
Marking a property as conditional allows enforcing it isn't accessed unless a given predicate returns true.  This can help not using properties for a feature if that feature is disabled entirely.