### PR TITLE
Change deprecation implementation

### DIFF
--- a/src/main/kotlin/org/jitsi/metaconfig/SupplierBuilder.kt
+++ b/src/main/kotlin/org/jitsi/metaconfig/SupplierBuilder.kt
@@ -29,7 +29,7 @@ class SupplierBuilder<T : Any>(val finalType: KType) {
     fun retrieve(context: String, lambda: () -> T) = retrieve(context, noDeprecation(), lambda)
 
     fun retrieve(context: String, deprecation: Deprecation, lambda: () -> T) {
-        suppliers += LambdaSupplier(context, deprecation, lambda)
+        suppliers += LambdaSupplier(context, lambda)
     }
 
     /**

--- a/src/main/kotlin/org/jitsi/metaconfig/SupplierBuilder.kt
+++ b/src/main/kotlin/org/jitsi/metaconfig/SupplierBuilder.kt
@@ -26,9 +26,7 @@ class SupplierBuilder<T : Any>(val finalType: KType) {
      * [LambdaSupplier]s don't require construction as they are entirely responsible for producing
      * the value, so they have their own method
      */
-    fun retrieve(context: String, lambda: () -> T) = retrieve(context, noDeprecation(), lambda)
-
-    fun retrieve(context: String, deprecation: Deprecation, lambda: () -> T) {
+    fun retrieve(context: String, lambda: () -> T) {
         suppliers += LambdaSupplier(context, lambda)
     }
 

--- a/src/main/kotlin/org/jitsi/metaconfig/supplier/ConditionalSupplier.kt
+++ b/src/main/kotlin/org/jitsi/metaconfig/supplier/ConditionalSupplier.kt
@@ -1,7 +1,6 @@
 package org.jitsi.metaconfig.supplier
 
 import org.jitsi.metaconfig.ConfigException
-import org.jitsi.metaconfig.noDeprecation
 
 /**
  * A [ConfigValueSupplier] which searches through multiple inner [ConfigValueSupplier]s, in order,
@@ -11,14 +10,13 @@ import org.jitsi.metaconfig.noDeprecation
 class ConditionalSupplier<ValueType : Any>(
     private val predicate: () -> Boolean,
     innerSuppliers: List<ConfigValueSupplier<ValueType>>
-) : ConfigValueSupplier<ValueType>(noDeprecation()) {
+) : ConfigValueSupplier<ValueType>() {
     private val innerSupplier = FallbackSupplier(innerSuppliers)
 
     override fun doGet(): ValueType {
         if (predicate()) {
             return innerSupplier.get()
-        }
-        else {
+        } else {
             throw ConfigException.UnableToRetrieve.ConditionNotMet("Predicate not met on conditional property")
         }
     }

--- a/src/main/kotlin/org/jitsi/metaconfig/supplier/ConfigValueSupplier.kt
+++ b/src/main/kotlin/org/jitsi/metaconfig/supplier/ConfigValueSupplier.kt
@@ -2,33 +2,19 @@ package org.jitsi.metaconfig.supplier
 
 import org.jitsi.metaconfig.ConfigException
 import org.jitsi.metaconfig.Deprecation
-import org.jitsi.metaconfig.MetaconfigSettings
 
 /**
  * A [ConfigValueSupplier] is a class which is responsible for retrieving the value
  * of a configuration property.
  */
-abstract class ConfigValueSupplier<ValueType : Any>(
-    private val deprecation: Deprecation
-) {
-    private var deprecationWarningLogged = false
-
-    private val value: ValueType by lazy {
-        doGet().also {
-            if (deprecation is Deprecation.Deprecated.Soft && !deprecationWarningLogged) {
-                MetaconfigSettings.logger.warn {
-                    "A value was retrieved via $this which is deprecated: ${deprecation.msg}"
-                }
-                deprecationWarningLogged = true
-            } else if (deprecation is Deprecation.Deprecated.Hard) {
-                throw ConfigException.UnableToRetrieve.Deprecated(
-                    "A value was retrieved via $this which is deprecated: ${deprecation.msg}"
-                )
-            }
-        }
-    }
+abstract class ConfigValueSupplier<ValueType : Any> {
+    private val value: ValueType by lazy { doGet() }
 
     fun get(): ValueType = value
+
+    // TODO: only 'source' suppliers should implement this.  enforce that with a lower-level
+    // abstract class?
+    open fun withDeprecation(deprecation: Deprecation): ConfigValueSupplier<ValueType> = this
 
     /**
      * Get the value from this supplier.  Throws [ConfigException.UnableToRetrieve]

--- a/src/main/kotlin/org/jitsi/metaconfig/supplier/ConfigValueSupplier.kt
+++ b/src/main/kotlin/org/jitsi/metaconfig/supplier/ConfigValueSupplier.kt
@@ -12,8 +12,13 @@ abstract class ConfigValueSupplier<ValueType : Any> {
 
     fun get(): ValueType = value
 
-    // TODO: only 'source' suppliers should implement this.  enforce that with a lower-level
-    // abstract class?
+    /**
+     * Apply a [Deprecation] to this [ConfigValueSupplier].  By default it does nothing.  This should
+     * only be overridden by classes which retrieve properties from some "source" (e.g. a file).
+     * Suppliers which wrap another an do some kind of transformation, for example,
+     * shouldn't override this.
+     *
+     */
     open fun withDeprecation(deprecation: Deprecation): ConfigValueSupplier<ValueType> = this
 
     /**

--- a/src/main/kotlin/org/jitsi/metaconfig/supplier/FallbackSupplier.kt
+++ b/src/main/kotlin/org/jitsi/metaconfig/supplier/FallbackSupplier.kt
@@ -13,7 +13,7 @@ import org.jitsi.metaconfig.noDeprecation
  */
 class FallbackSupplier<ValueType : Any>(
     private val suppliers: List<ConfigValueSupplier<ValueType>>
-) : ConfigValueSupplier<ValueType>(noDeprecation()) {
+) : ConfigValueSupplier<ValueType>() {
 
     override fun doGet(): ValueType {
         MetaconfigSettings.logger.debug {

--- a/src/main/kotlin/org/jitsi/metaconfig/supplier/LambdaSupplier.kt
+++ b/src/main/kotlin/org/jitsi/metaconfig/supplier/LambdaSupplier.kt
@@ -1,16 +1,12 @@
 package org.jitsi.metaconfig.supplier
 
-import org.jitsi.metaconfig.Deprecation
 import org.jitsi.metaconfig.MetaconfigSettings
 
 class LambdaSupplier<ValueType : Any>(
     private val context: String,
-    deprecation: Deprecation,
     private val supplier: () -> ValueType
-) : ConfigValueSupplier<ValueType>(deprecation) {
-    constructor(supplier: () -> ValueType) : this("", Deprecation.NotDeprecated, supplier)
-    constructor(deprecation: Deprecation, supplier: () -> ValueType) : this("", deprecation, supplier)
-    constructor(context: String, supplier: () -> ValueType) : this(context, Deprecation.NotDeprecated, supplier)
+) : ConfigValueSupplier<ValueType>() {
+    constructor(supplier: () -> ValueType) : this("", supplier)
 
     override fun doGet(): ValueType {
         MetaconfigSettings.logger.debug {

--- a/src/main/kotlin/org/jitsi/metaconfig/supplier/TypeConvertingSupplier.kt
+++ b/src/main/kotlin/org/jitsi/metaconfig/supplier/TypeConvertingSupplier.kt
@@ -13,7 +13,7 @@ import org.jitsi.metaconfig.noDeprecation
 class TypeConvertingSupplier<OriginalType : Any, NewType : Any>(
     private val originalSupplier: ConfigValueSupplier<OriginalType>,
     private val converter: (OriginalType) -> NewType
-) : ConfigValueSupplier<NewType>(noDeprecation()) {
+) : ConfigValueSupplier<NewType>() {
 
     override fun doGet(): NewType {
         return converter(originalSupplier.get()).also {

--- a/src/main/kotlin/org/jitsi/metaconfig/supplier/ValueTransformingSupplier.kt
+++ b/src/main/kotlin/org/jitsi/metaconfig/supplier/ValueTransformingSupplier.kt
@@ -12,7 +12,7 @@ import org.jitsi.metaconfig.noDeprecation
 class ValueTransformingSupplier<ValueType : Any>(
     private val originalSupplier: ConfigValueSupplier<ValueType>,
     private val transformer: (ValueType) -> ValueType
-) : ConfigValueSupplier<ValueType>(noDeprecation()) {
+) : ConfigValueSupplier<ValueType>() {
 
     override fun doGet(): ValueType {
         return transformer(originalSupplier.get()).also {

--- a/src/test/kotlin/org/jitsi/MockLogger.kt
+++ b/src/test/kotlin/org/jitsi/MockLogger.kt
@@ -2,28 +2,34 @@ package org.jitsi
 
 import org.jitsi.metaconfig.MetaconfigLogger
 
-class MockLogger : MetaconfigLogger {
+class MockLogger(val printToStdOut: Boolean = false) : MetaconfigLogger {
     val errorMessages = mutableListOf<String>()
     val warnMessages = mutableListOf<String>()
     val debugMessages = mutableListOf<String>()
 
     override fun debug(block: () -> String) {
         block().apply {
-            println("DEBUG: $this")
+            if (printToStdOut) {
+                println("DEBUG: $this")
+            }
             debugMessages += this
         }
     }
 
     override fun error(block: () -> String) {
         block().apply {
-            println("ERROR: $this")
+            if (printToStdOut) {
+                println("ERROR: $this")
+            }
             errorMessages += this
         }
     }
 
     override fun warn(block: () -> String) {
         block().apply {
-            println("WARN: $this")
+            if (printToStdOut) {
+                println("WARN: $this")
+            }
             warnMessages += this
         }
     }

--- a/src/test/kotlin/org/jitsi/metaconfig/supplier/ConfigValueSupplierTest.kt
+++ b/src/test/kotlin/org/jitsi/metaconfig/supplier/ConfigValueSupplierTest.kt
@@ -6,12 +6,17 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldMatch
 import org.jitsi.MockLogger
 import org.jitsi.metaconfig.ConfigException
+import org.jitsi.metaconfig.MapConfigSource
 import org.jitsi.metaconfig.MetaconfigSettings
 import org.jitsi.metaconfig.hardDeprecation
 import org.jitsi.metaconfig.softDeprecation
+import kotlin.reflect.typeOf
 
 class ConfigValueSupplierTest : ShouldSpec({
     val mockLogger = MockLogger()
+    val config = MapConfigSource("config") {
+        put("new.num", 42)
+    }
     beforeSpec {
         MetaconfigSettings.logger = mockLogger
     }
@@ -47,7 +52,8 @@ class ConfigValueSupplierTest : ShouldSpec({
         }
         context("marked as soft deprecated") {
             context("that finds a value") {
-                val s = LambdaSupplier(softDeprecation("deprecated")) { 42 }
+                val s = ConfigSourceSupplier<Int>(
+                    "new.num", config, typeOf<Int>(), softDeprecation("deprecated"))
                 should("log a warning") {
                     s.get() shouldBe 42
                     mockLogger.warnMessages.any {
@@ -56,9 +62,8 @@ class ConfigValueSupplierTest : ShouldSpec({
                 }
             }
             context("that doesn't find a value") {
-                val s = LambdaSupplier<Int>(softDeprecation("deprecated")) {
-                    throw ConfigException.UnableToRetrieve.NotFound("not found")
-                }
+                val s = ConfigSourceSupplier<Int>(
+                    "missing.num", config, typeOf<Int>(), softDeprecation("deprecated"))
                 should("not log a warning") {
                     shouldThrow<ConfigException.UnableToRetrieve.NotFound> {
                         s.get()
@@ -71,7 +76,8 @@ class ConfigValueSupplierTest : ShouldSpec({
         }
         context("marked as hard deprecated") {
             context("that finds a value") {
-                val s = LambdaSupplier(hardDeprecation("deprecated")) { 42 }
+                val s = ConfigSourceSupplier<Int>(
+                    "new.num", config, typeOf<Int>(), hardDeprecation("deprecated"))
                 should("throw an exception") {
                     val ex = shouldThrow<ConfigException.UnableToRetrieve.Deprecated> {
                         s.get()
@@ -80,9 +86,8 @@ class ConfigValueSupplierTest : ShouldSpec({
                 }
             }
             context("that doesn't find a value") {
-                val s = LambdaSupplier<Int>(hardDeprecation("deprecated")) {
-                    throw ConfigException.UnableToRetrieve.NotFound("not found")
-                }
+                val s = ConfigSourceSupplier<Int>(
+                    "missing.num", config, typeOf<Int>(), hardDeprecation("deprecated"))
                 should("throw the UnableToRetrieve exception") {
                     shouldThrow<ConfigException.UnableToRetrieve.NotFound> {
                         s.get()

--- a/src/test/kotlin/org/jitsi/metaconfig/supplier/ConfigValueSupplierTest.kt
+++ b/src/test/kotlin/org/jitsi/metaconfig/supplier/ConfigValueSupplierTest.kt
@@ -60,6 +60,15 @@ class ConfigValueSupplierTest : ShouldSpec({
                         it.contains(Regex(".*A value was retrieved via .* which is deprecated: deprecated"))
                     } shouldBe true
                 }
+                context("even when wrapped") {
+                    val t = ValueTransformingSupplier(s) { it + 1}
+                    should("log a warning") {
+                        s.get() shouldBe 42
+                        mockLogger.warnMessages.any {
+                            it.contains(Regex(".*A value was retrieved via .* which is deprecated: deprecated"))
+                        } shouldBe true
+                    }
+                }
             }
             context("that doesn't find a value") {
                 val s = ConfigSourceSupplier<Int>(


### PR DESCRIPTION
It only makes sense to model deprecation at the level of a supplier which is retrieving a property from some external source--currently only `ConfigSourceSupplier`.  So instead of delaying creation of Suppliers in ConfigPropertyState, create the underlying 'source supplier' whenever we can and pass that created type to the transforming, etc. suppliers.  The transforming suppliers can now propagate a deprecation down to their inner suppliers which can trickle it down further or apply it, where applicable.

This change would also enable chaining together `.andTransformBy` and `.andConvertBy` calls since those states now wrap an opaque `ConfigValueSupplier`, making it easier to add additional wrappers.