### PR TITLE
Tweak conditional properties

### DIFF
--- a/src/main/kotlin/org/jitsi/metaconfig/Condition.kt
+++ b/src/main/kotlin/org/jitsi/metaconfig/Condition.kt
@@ -1,0 +1,10 @@
+package org.jitsi.metaconfig
+
+data class Condition(
+    val context: String,
+    private val predicate: () -> Boolean
+) {
+    fun enabled(): Boolean = predicate()
+}
+
+val AlwaysEnabled = Condition("") { true }

--- a/src/main/kotlin/org/jitsi/metaconfig/Delegates.kt
+++ b/src/main/kotlin/org/jitsi/metaconfig/Delegates.kt
@@ -1,6 +1,5 @@
 package org.jitsi.metaconfig
 
-import org.jitsi.metaconfig.supplier.ConditionalSupplier
 import org.jitsi.metaconfig.supplier.ConfigValueSupplier
 import org.jitsi.metaconfig.supplier.FallbackSupplier
 import kotlin.reflect.KProperty
@@ -50,7 +49,12 @@ inline fun <reified T : Any> config(configPropertyState: ConfigPropertyState.Inc
  */
 inline fun <reified T : Any> config(block: SupplierBuilder<T>.() -> Unit): ConfigDelegate<T> {
     val supplier = SupplierBuilder<T>(typeOf<T>()).apply(block)
-    return ConfigDelegate(FallbackSupplier(supplier.suppliers))
+    return if (supplier.suppliers.size == 1) {
+        // Avoid wrapping in a FallbackSupplier if we don't need one
+        ConfigDelegate(supplier.suppliers.first())
+    } else {
+        return ConfigDelegate(FallbackSupplier(supplier.suppliers))
+    }
 }
 
 /**
@@ -82,9 +86,4 @@ inline fun <reified T : Any> optionalconfig(configPropertyState: ConfigPropertyS
 inline fun <reified T : Any> optionalconfig(block: SupplierBuilder<T>.() -> Unit): OptionalConfigDelegate<T> {
     val builder = SupplierBuilder<T>(typeOf<T>()).apply(block)
     return OptionalConfigDelegate(FallbackSupplier(builder.suppliers))
-}
-
-inline fun <reified T : Any> conditionalconfig(noinline predicate: () -> Boolean, block: SupplierBuilder<T>.() -> Unit): ConfigDelegate<T> {
-    val supplier = SupplierBuilder<T>(typeOf<T>()).apply(block)
-    return ConfigDelegate(ConditionalSupplier(predicate, supplier.suppliers))
 }

--- a/src/main/kotlin/org/jitsi/metaconfig/Delegates.kt
+++ b/src/main/kotlin/org/jitsi/metaconfig/Delegates.kt
@@ -21,6 +21,8 @@ class OptionalConfigDelegate<T : Any>(private val supplier: ConfigValueSupplier<
     operator fun getValue(thisRef: Any, property: KProperty<*>): T? {
         return try {
             supplier.get()
+        } catch (e: ConfigException.UnableToRetrieve.ConditionNotMet) {
+            throw e
         } catch (t: ConfigException.UnableToRetrieve) {
             null
         }
@@ -84,6 +86,11 @@ inline fun <reified T : Any> optionalconfig(configPropertyState: ConfigPropertyS
  * null if the property couldn't be retrieved
  */
 inline fun <reified T : Any> optionalconfig(block: SupplierBuilder<T>.() -> Unit): OptionalConfigDelegate<T> {
-    val builder = SupplierBuilder<T>(typeOf<T>()).apply(block)
-    return OptionalConfigDelegate(FallbackSupplier(builder.suppliers))
+    val supplier = SupplierBuilder<T>(typeOf<T>()).apply(block)
+    return if (supplier.suppliers.size == 1) {
+        // Avoid wrapping in a FallbackSupplier if we don't need one
+        OptionalConfigDelegate(supplier.suppliers.first())
+    } else {
+        return OptionalConfigDelegate(FallbackSupplier(supplier.suppliers))
+    }
 }

--- a/src/main/kotlin/org/jitsi/metaconfig/SupplierBuilder.kt
+++ b/src/main/kotlin/org/jitsi/metaconfig/SupplierBuilder.kt
@@ -2,6 +2,7 @@
 
 package org.jitsi.metaconfig
 
+import org.jitsi.metaconfig.supplier.ConditionalSupplier
 import org.jitsi.metaconfig.supplier.ConfigValueSupplier
 import org.jitsi.metaconfig.supplier.LambdaSupplier
 import kotlin.reflect.KType
@@ -29,6 +30,13 @@ class SupplierBuilder<T : Any>(val finalType: KType) {
     fun retrieve(context: String, lambda: () -> T) {
         suppliers += LambdaSupplier(context, lambda)
     }
+
+    fun onlyIf(condition: Condition, block: SupplierBuilder<T>.() -> Unit) {
+        val supplier = SupplierBuilder<T>(finalType).apply(block)
+        suppliers += ConditionalSupplier(condition, supplier.suppliers)
+    }
+    fun onlyIf(context: String, predicate: () -> Boolean, block: SupplierBuilder<T>.() -> Unit) =
+        onlyIf(Condition(context, predicate), block)
 
     /**
      * Once the key and source are set, automatically set the inferred type.  If the user wants to retrieve

--- a/src/main/kotlin/org/jitsi/metaconfig/supplier/ConditionalSupplier.kt
+++ b/src/main/kotlin/org/jitsi/metaconfig/supplier/ConditionalSupplier.kt
@@ -1,5 +1,6 @@
 package org.jitsi.metaconfig.supplier
 
+import org.jitsi.metaconfig.Condition
 import org.jitsi.metaconfig.ConfigException
 
 /**
@@ -8,16 +9,16 @@ import org.jitsi.metaconfig.ConfigException
  * [ConfigException.UnableToRetrieve.ConditionNotMet] is thrown.
  */
 class ConditionalSupplier<ValueType : Any>(
-    private val predicate: () -> Boolean,
+    private val condition: Condition,
     innerSuppliers: List<ConfigValueSupplier<ValueType>>
 ) : ConfigValueSupplier<ValueType>() {
     private val innerSupplier = FallbackSupplier(innerSuppliers)
 
     override fun doGet(): ValueType {
-        if (predicate()) {
+        if (condition.enabled()) {
             return innerSupplier.get()
         } else {
-            throw ConfigException.UnableToRetrieve.ConditionNotMet("Predicate not met on conditional property")
+            throw ConfigException.UnableToRetrieve.ConditionNotMet("Condition not met: ${condition.context}")
         }
     }
 

--- a/src/test/kotlin/org/jitsi/metaconfig/ConfigPropertyStateTest.kt
+++ b/src/test/kotlin/org/jitsi/metaconfig/ConfigPropertyStateTest.kt
@@ -88,5 +88,27 @@ class ConfigPropertyStateTest : ShouldSpec({
                 obj.disabledNum
             }
         }
+        should("throw if an optional, conditional property is disabled") {
+            val obj = object {
+                val num: Int? by optionalconfig {
+                    onlyIf("enabled", { false }) {
+                        retrieve("new.num".from(newConfig))
+                    }
+                }
+            }
+            shouldThrow<ConfigException.UnableToRetrieve.ConditionNotMet> {
+                obj.num
+            }
+        }
+        should("return null if an optional, conditional property is enabled but not found") {
+            val obj = object {
+                val num: Int? by optionalconfig {
+                    onlyIf("enabled", { true }) {
+                        retrieve("missing.num".from(newConfig))
+                    }
+                }
+            }
+            obj.num shouldBe null
+        }
     }
 })

--- a/src/test/kotlin/org/jitsi/metaconfig/ConfigPropertyStateTest.kt
+++ b/src/test/kotlin/org/jitsi/metaconfig/ConfigPropertyStateTest.kt
@@ -72,11 +72,15 @@ class ConfigPropertyStateTest : ShouldSpec({
         }
         should("allow conditionally enabling a property") {
             val obj = object {
-                val enabledNum: Int by conditionalconfig({true}) {
-                    retrieve("new.num".from(newConfig))
+                val enabledNum: Int by config {
+                    onlyIf("enabled", { true }) {
+                        retrieve("new.num".from(newConfig))
+                    }
                 }
-                val disabledNum: Int by conditionalconfig({false}) {
-                    retrieve("new.num".from(newConfig))
+                val disabledNum: Int by config {
+                    onlyIf("enabled", { false} ) {
+                        retrieve("new.num".from(newConfig))
+                    }
                 }
             }
             obj.enabledNum shouldBe 43

--- a/src/test/kotlin/org/jitsi/metaconfig/supplier/ConditionalSupplierTest.kt
+++ b/src/test/kotlin/org/jitsi/metaconfig/supplier/ConditionalSupplierTest.kt
@@ -3,13 +3,14 @@ package org.jitsi.metaconfig.supplier
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
+import org.jitsi.metaconfig.Condition
 import org.jitsi.metaconfig.ConfigException
 
 class ConditionalSupplierTest : ShouldSpec({
     context("a conditional supplier") {
         context("when the condition is met") {
             val cs = ConditionalSupplier<Int>(
-                { true },
+                Condition("enabled", { true }),
                 listOf(
                     LambdaSupplier { 42 }
                 )
@@ -20,7 +21,7 @@ class ConditionalSupplierTest : ShouldSpec({
         }
         context("when the condition is not met") {
             val cs = ConditionalSupplier<Int>(
-                { false },
+                Condition("enabled", { false }),
                 listOf(
                     LambdaSupplier { 42 }
                 )


### PR DESCRIPTION
The top-level `conditionalconfig` delegate was too restricting, and couldn't work with things like optional properties.  This PR changes the implementation of conditional by adding some new builder helpers to denote conditional properties.  Since the condition applies to the entire property (as of now, at least), this had to be done at a level above all the individual property builders.